### PR TITLE
Prevent admin user from deletion

### DIFF
--- a/internal/controller/membership/membership.go
+++ b/internal/controller/membership/membership.go
@@ -217,6 +217,12 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 
 	name := meta.GetExternalName(cr)
+	role := cr.Spec.ForProvider.Role
+
+	if role == "admin" {
+		return errors.New("You can only delete member users. Admin users cannot be deleted")
+	}
+
 	_, err := c.github.Organizations.RemoveOrgMembership(ctx, name, cr.Spec.ForProvider.Org)
 	if err != nil {
 		return err


### PR DESCRIPTION
If attempt to delete admin user the provider will output and error in the logs and the crossplane resource will have error status.
